### PR TITLE
Remove un-used Facebook icon

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,8 +21,6 @@ footer:
 social:
   - title: twitter
     url: http://twitter.com/anzcoders
-  - title: facebook
-    url:
   - title: youtube
     url: http://youtube.com/anzcoders
   - title: envelope-o


### PR DESCRIPTION
It's falling back to the web URL instead, which is misleading
